### PR TITLE
Added fix for non-present options

### DIFF
--- a/src/components/content/ContentTagger.tsx
+++ b/src/components/content/ContentTagger.tsx
@@ -102,7 +102,8 @@ function ContentTagger<
       handleHomeEndKeys
       selectOnFocus
       value={props.selected}
-      options={props.options}
+      options={[...props.options, ...props.selected ?? []]}
+      getOptionSelected={(option, val) => option.id === val.id}
       getOptionLabel={option => option.name}
       renderInput={(params) => (
         <TextField


### PR DESCRIPTION
During async loading, the tagged metadata for a piece of content is often not loaded yet.
Hence, to avoid the warning that none of the options match with the selected values, the selected values have been spread into the options of the MetadataTagger.