### PR TITLE
Changed datePublished to optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ interface BaseContent<M extends BaseMetadata = BaseMetadata> {
     id: number;
     description: string;
     fileName: string;
-    datePublished: string;
+    datePublished?: string;
     copyright?: string;
     rightsStatement?: string;
     metadata: Record<number, M[]>;


### PR DESCRIPTION
Published Year field on content form will not be required, hence datePublished should be optional as well to reflect this.