### PR TITLE
Added FormField type export (for very specific use in CC)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import KebabMenu from './components/KebabMenu';
 import KebabMenuItem from './components/KebabMenuItem';
 import DataTable from './components/DataTable';
 import ExpandPanel from './components/ExpandPanel';
-import Form from './components/Form';
+import Form, { FormFieldDescriptor } from './components/Form';
 import Selection from './components/Selection';
 import {
   MetadataDisplay,
@@ -57,4 +57,5 @@ export {
 
 export type {
   BaseMetadata, BaseMetadataType, BaseContent,
+  FormFieldDescriptor,
 };


### PR DESCRIPTION
Content Curation requires this very specific type to be exported, so I've added it.
There's probably a better way to export types, but this is a quick fix